### PR TITLE
サブタイトルworkが横に並ばないように種末い

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -84,7 +84,7 @@ a {
   display: block;
   border-bottom: 2px dashed rgba(184, 48, 235, 0.73);
   margin: 2rem 0 1rem 0;
-  position: absolute;
+  width: 100%;
 }
 
 .work img {


### PR DESCRIPTION
## workのサブタイトル
> ①workのところ、色々いじってたらサブタイトルの収まりがつかなくて、戻れなくなってしまいいました。そもそもdisplay:block指定しているのに横並びになっているのがよくわかりません。

こちらに関しては、position: absoluteを指定すると、親要素の左上がデフォルト配置になります。
今回だったら、workクラスの左上から設定されたmargin分スペースをとった位置に配置されます。
<img width="1436" alt="スクリーンショット 2020-07-11 21 50 03" src="https://user-images.githubusercontent.com/23383717/87224456-86261000-c3c0-11ea-96a7-cae9e3298bbd.png">
absoluteは要素を重ねて配置したりするときに使いたいので、今回のサブタイトルを表示するのは適さないので、
absoluteは削除しました。

## フォントの適応
> ②このフォント、スマホ表示だと違うフォントになってしまいます。お洒落なフォントにしようとするとしょうがないんですかね…ちなみにもともとPCに入ってたフォントです。

僕のPCにはフォントが入っていないので、フォントは変更されていませんでした・・・。おそらくスマホにもフォントがないのでしょう。

デフォルトで指定できるフォント一覧
https://w3g.jp/sample/css/font-family

基本的にフォントを返る時は、フォントファイルを落として、ファイルに配置してあげるか、webフォントを指定してあげます。
参考: https://www.softel.co.jp/blogs/tech/archives/3676

ちなみに、googleが用意してくれているwebフォントを使ってあげた方が、コードをコピペするだけで、どのブラウザでも変更されるようになって手軽です。